### PR TITLE
fix: pagination logic

### DIFF
--- a/src/models/Subscriber.js
+++ b/src/models/Subscriber.js
@@ -90,6 +90,7 @@ class Subscriber {
 
       // set new offset and get next page number
       const newOffset = this.pageLimit + offset;
+      console.log(offset, newOffset);
       const nextPageNum = await Util.
         getNextPage(newOffset, this.pageLimit, TABLES.SUBSCRIBERS);
 

--- a/src/models/Subscriber.js
+++ b/src/models/Subscriber.js
@@ -90,7 +90,7 @@ class Subscriber {
 
       // set new offset and get next page number
       const newOffset = this.pageLimit + offset;
-      console.log(offset, newOffset);
+
       const nextPageNum = await Util.
         getNextPage(newOffset, this.pageLimit, TABLES.SUBSCRIBERS);
 

--- a/src/utils/pagination.js
+++ b/src/utils/pagination.js
@@ -13,10 +13,34 @@ const getOffset = (pageNum, pageLimit) => {
 }
 
 /**
+ * Computes the number of rows on a table
+ * @param {string} tableName name of table rows to be counted 
+ * @returns {Promise<number | string>}
+ */
+const getCountTableRows = async (tableName) => {
+
+    const memoizedObj = {};
+
+    const tableCount = `${tableName}Count`;
+
+    if (!memoizedObj.tableCount) {
+        const [result] = await db(tableName)
+            .count('id', { as: 'rowsCount' })
+
+        memoizedObj[tableCount] = result.rowsCount;
+
+        return memoizedObj[tableCount];
+    }
+
+    return memoizedObj[tableCount];
+
+}
+
+/**
  * @async
  * computes the next number of rows in `table` for the next page
  * for pagination
- * @param {number} offset
+ * @param {number} offset new offset for requested page
  * @param {number} pageLimit
  * @param {string} table table to be queried
  * @returns {Promise<number | null>} next page number
@@ -25,30 +49,31 @@ const getNextPage = async (offset, pageLimit, table) => {
     /**@type {number | null} */
     let nextPageNum = null;
     /** @type {number} */
-    let nextPageCount;
 
-    // get rows count for next page
-    // { rowsCount: number } is returned
-    const [nextPage] = await db(table)
-        .count('id as rowsCount')
-        .limit(pageLimit)
-        .offset(offset)
+    let rowsCount;
 
-    // no next rows
-    if (!nextPage) {
+    // get rows count for table
+
+    const totalRowsCount = await getCountTableRows(table);
+    if (typeof totalRowsCount === 'string') {
+        rowsCount = parseInt(totalRowsCount, 10);
+    } else {
+        rowsCount = totalRowsCount;
+    }
+
+    // resources count in previous pages
+    const itemsRendered = offset - pageLimit;
+
+    // amount of resources unrendered
+    const remainder = rowsCount - (itemsRendered + pageLimit);
+
+    // no more resources to fetch
+    if (remainder <= 0) {
         return nextPageNum;
     }
 
-    const { rowsCount } = nextPage;
-    // parse string type
-    if (typeof rowsCount === 'string') {
-        nextPageCount = parseInt(rowsCount, 10);
-    } else {
-        nextPageCount = rowsCount;
-    }
-
     // compute next page number
-    nextPageNum = nextPageCount > 0 ? (offset / pageLimit) + 1 : 0;
+    nextPageNum = (offset / pageLimit) + 1;
 
     return nextPageNum;
 


### PR DESCRIPTION
The logic will be updated to allow caching of queries. The current method of computing the next page number uses a `COUNT(id)` to get the total number of rows in a given table, which can be cached in an in-memory database like redis. This will effectively reduce the round-trip queries in a single request-response cycle. Only insertions or deletions will trigger a recount of the rows on the table.